### PR TITLE
several small/medium items

### DIFF
--- a/postgresql-simple-opts.cabal
+++ b/postgresql-simple-opts.cabal
@@ -15,7 +15,7 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Database.PostgreSQL.Simple.Options
+  exposed-modules:     Database.PostgreSQL.Simple.PartialOptions
   build-depends: base >= 4.6 && < 5
                , postgresql-simple
                , optparse-applicative
@@ -26,6 +26,7 @@ library
                , split
                , uri-bytestring
                , generic-deriving
+               , postgres-options
   default-language:    Haskell2010
   ghc-options: -Wall
                -fno-warn-unused-do-bind
@@ -41,6 +42,7 @@ test-suite postgresql-simple-opts-test
                      , optparse-applicative
                      , bytestring
                      , data-default
+                     , postgres-options
   ghc-options: -Wall
                -fno-warn-unused-do-bind
                -threaded

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,8 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  - postgres-options-0.1.0.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings, CPP #-}
 import Test.Hspec
-import Database.PostgreSQL.Simple.Options
+import Database.PostgreSQL.Simple.PartialOptions
 import System.Environment
 import Options.Applicative
 import System.Exit


### PR DESCRIPTION
* renamed module Options to PartialOptions
* removed the toConnectionString and toArgs functions because they are now in postgres-options.
* reorganized imports and language extensions
* some very small cleanups